### PR TITLE
Adding recipe containing different ways to create Opportunities with …

### DIFF
--- a/snowfakery_samples/npsp/OpportunitiesWithAllocations.yml
+++ b/snowfakery_samples/npsp/OpportunitiesWithAllocations.yml
@@ -1,0 +1,133 @@
+# This recipe is made up of 3 sub-recipes:
+# 1 - Creating an Opportunity with a GAU Allocation at 100% of the Opportunity Amount.
+# 2 - Creating an Opportunity with 2 GAU Allocations with known percentages.
+# 3 - Creating an Opportunity with 2 GAU Allocations with random amounts adding up to the Opportunity Amount.
+
+# To run this file, use a command such as the following:
+# cci task run generate_and_load_from_yaml -o generator_yaml ../Snowfakery-new/examples/npsp/OpportunityWithAllocations.yml -o num_records 1 -o num_records_tablename Account --org qa
+
+
+# Setup Step 1: Create 3 Accounts
+- object: Account
+  count: 3
+  fields:
+    Name:
+      fake: company
+
+
+# Setup Step 2: Create 3 General Accounting Units that are Active.
+
+- object: npsp__General_Accounting_Unit__c
+  nickname: GAU_GenOps
+  fields:
+    Name: General Operating Fund
+    Active__c: true
+
+- object: npsp__General_Accounting_Unit__c
+  nickname: GAU_Edu
+  fields:
+    Name: Education Fund
+    Active__c: true
+
+- object: npsp__General_Accounting_Unit__c
+  nickname: GAU_Animal
+  fields:
+    Name: Animal Fund
+    Active__c: true
+
+
+### Scenario 1: Create an Opportunity with 1 GAU Allocation at 100% of the Opportunity Amount
+- object: Opportunity
+  fields:
+    AccountId:
+      random_reference: Account
+    Name: 1 GAU Opportunity for ${{Account.Name}}
+    Amount:
+      random_number:
+        min: 10
+        max: 1000
+    StageName: Pledged
+    CloseDate:
+      date_between:
+        start_date: 2020-01-01
+        end_date: today
+  friends:
+    - object: npsp__Allocation__c
+      fields:
+        npsp__General_Accounting_Unit__c:
+          reference: GAU_GenOps
+        npsp__Opportunity__c:
+          reference: Opportunity
+        npsp__Amount__c: ${{Opportunity.Amount}}
+
+
+### Scenario 2: Create an Opportunity with 2 GAU Allocations using a known percentage split
+- object: Opportunity
+  fields:
+    AccountId:
+      random_reference: Account
+    Name: 2 GAU Opportunity for ${{Account.Name}}
+    Amount:
+      random_number:
+        min: 10
+        max: 1000
+    StageName: Pledged
+    CloseDate:
+      date_between:
+        start_date: 2020-01-01
+        end_date: today
+  friends:
+    - object: npsp__Allocation__c
+      fields:
+        npsp__General_Accounting_Unit__c:
+          reference: GAU_Edu
+        npsp__Opportunity__c:
+          reference: Opportunity
+        npsp__Percent__c: 75
+    - object: npsp__Allocation__c
+      fields:
+        npsp__General_Accounting_Unit__c:
+          reference: GAU_Animal
+        npsp__Opportunity__c:
+          reference: Opportunity
+        npsp__Percent__c: 25
+
+
+### Scenario 3: Create an Opportunity with 2 GAU Allocations using a random Amount split
+### This uses a variable to get a random Amount based on the Opportunity's Amount
+### and then uses formulas to get the correct random Amounts between the 2 Allocations.
+- object: Opportunity
+  fields:
+    AccountId:
+      random_reference: Account
+    Name: 2 GAU (Random Amount) Opportunity for ${{Account.Name}}
+    Amount:
+      random_number:
+        min: 10
+        max: 1000
+    StageName: Pledged
+    CloseDate:
+      date_between:
+        start_date: 2020-01-01
+        end_date: today
+  friends:
+    - var: randomAmount
+      value:
+        random_number:
+          min: 1
+          max: ${{Opportunity.Amount - 1}}
+    - object: npsp__Allocation__c
+      nickname: allocation1
+      fields:
+        npsp__General_Accounting_Unit__c:
+          reference: GAU_Edu
+        npsp__Opportunity__c:
+          reference: Opportunity
+        npsp__Amount__c: ${{Opportunity.Amount - randomAmount}}
+    - object: npsp__Allocation__c
+      fields:
+        npsp__General_Accounting_Unit__c:
+          reference: GAU_Animal
+        npsp__Opportunity__c:
+          reference: Opportunity
+        npsp__Amount__c: ${{Opportunity.Amount - allocation1.npsp__Amount__c}}


### PR DESCRIPTION
Adding new npsp Snowfakery recipe for creating Opportunities with Allocations. The recipe file is made up of several "sub-recipes":
1 - Creating an Opportunity with a GAU Allocation at 100% of the Opportunity Amount.
2 - Creating an Opportunity with 2 GAU Allocations with known percentages.
3 - Creating an Opportunity with 2 GAU Allocations with random amounts adding up to the Opportunity Amount.

# Critical Changes

# Changes

# Issues Closed
#64 