### PR TITLE
Remove CleanStatus

### DIFF
--- a/snowfakery_samples/salesforce/Contact.recipe.yml
+++ b/snowfakery_samples/salesforce/Contact.recipe.yml
@@ -139,13 +139,3 @@
       fake.text:
         max_nb_chars: 100
     EmailBouncedDate: ${{fake.date}}T${{fake.time}}Z
-    CleanStatus:
-      random_choice:
-        - Matched
-        - Different
-        - Acknowledged
-        - NotFound
-        - Inactive
-        - Pending
-        # - SelectMatch  # causes problems
-        - Skipped


### PR DESCRIPTION

# Critical Changes
Removes the CleanStatus field from the Contact template because it's not available in many orgs.

# Issues Closed
Fixes #120 